### PR TITLE
Update appengine's libraries

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,10 +1,10 @@
 package twiliogae
 
 import (
-	"appengine"
-	"appengine/urlfetch"
 	"encoding/json"
 	"fmt"
+	"golang.org/x/net/context"
+	"google.golang.org/appengine/urlfetch"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -16,7 +16,7 @@ type Client interface {
 	AccountSid() string
 	AuthToken() string
 	RootUrl() string
-	post(appengine.Context, url.Values, string) ([]byte, error)
+	post(context.Context, url.Values, string) ([]byte, error)
 }
 
 type TwilioClient struct {
@@ -30,7 +30,7 @@ func NewClient(accountSid, authToken string) *TwilioClient {
 	return &TwilioClient{accountSid, authToken, rootUrl}
 }
 
-func (client *TwilioClient) post(c appengine.Context, values url.Values, uri string) ([]byte, error) {
+func (client *TwilioClient) post(c context.Context, values url.Values, uri string) ([]byte, error) {
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s%s", "https://api.twilio.com", uri), strings.NewReader(values.Encode()))
 
 	if err != nil {
@@ -40,7 +40,10 @@ func (client *TwilioClient) post(c appengine.Context, values url.Values, uri str
 	req.SetBasicAuth(client.AccountSid(), client.AuthToken())
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
-	tr := &urlfetch.Transport{Context: c, Deadline: time.Duration(30) * time.Second}
+	tr := &urlfetch.Transport{
+		Context:  c,
+		Deadline: time.Duration(30) * time.Second,
+	}
 
 	res, err := tr.RoundTrip(req)
 	if err != nil {

--- a/example.go
+++ b/example.go
@@ -1,0 +1,58 @@
+package twiliogae
+
+import (
+	"flag"
+	"fmt"
+	"golang.org/x/net/context"
+	"google.golang.org/appengine"
+	"google.golang.org/appengine/log"
+	"html/template"
+	"net/http"
+)
+
+var (
+	twilioSID    = flag.String("twilioSID", "111111111", "twilio sid auth")
+	twilioToken  = flag.String("twilioToken", "111111111", "twilio token auth")
+	twilioNumber = flag.String("twilioNumber", "+111111111", "twilio sms capable number")
+	twilioClient = NewClient(*twilioSID, *twilioToken)
+)
+
+var templates = template.Must(template.ParseGlob("templates/*"))
+
+func init() {
+	http.HandleFunc("/", root)
+	http.HandleFunc("/sms", SmsHandler)
+}
+
+func root(w http.ResponseWriter, r *http.Request) {
+	templates.ExecuteTemplate(w, "test.html", nil)
+}
+
+func SmsHandler(w http.ResponseWriter, r *http.Request) {
+	qs := r.URL.Query()
+	to := qs.Get("to")
+	body := qs.Get("body")
+	c := appengine.NewContext(r)
+	if err := SendSMS(c, to, body); err != nil {
+		log.Errorf(c, err.Error())
+	} else {
+		log.Infof(c, "sms sent succesfully to %s", to)
+	}
+}
+
+func SendSMS(c context.Context, to string, body string) error {
+	if len(body) == 0 {
+		return fmt.Errorf("must contain 'body'")
+	}
+	if len(to) == 0 {
+		return fmt.Errorf("must contain 'to' number")
+	}
+	message, err := NewMessage(c, twilioClient, *twilioNumber, to, Body(body))
+
+	if err != nil {
+		return err
+	} else {
+		fmt.Println(message.Status)
+	}
+	return nil
+}

--- a/message.go
+++ b/message.go
@@ -1,8 +1,8 @@
 package twiliogae
 
 import (
-	"appengine"
 	"encoding/json"
+	"golang.org/x/net/context"
 	"net/url"
 )
 
@@ -24,7 +24,7 @@ type Message struct {
 	Uri         string `json:"uri"`
 }
 
-func NewMessage(c appengine.Context, client Client, from string, to string, content ...Optional) (*Message, error) {
+func NewMessage(c context.Context, client Client, from string, to string, content ...Optional) (*Message, error) {
 	var message *Message
 
 	params := url.Values{}


### PR DESCRIPTION
- appengine replaced by google.golang.org/appengine
- appengine.Context has been replaced with the Context type from golang.org/x/net/context.
- Logging methods have been replaced by google.golang.org/appengine/log
- urlfetch replaced by google.golang.org/appengine/urlfetch